### PR TITLE
fix: Adds erlang:timestamp() to typespec

### DIFF
--- a/src/jsx.erl
+++ b/src/jsx.erl
@@ -48,6 +48,7 @@
     | true | false | null
     | integer() | float()
     | binary() | atom()
+    | erlang:timestamp()
     | calendar:datetime().
 
 -type json_text() :: binary().


### PR DESCRIPTION
This is supported in `jsx_parser` which calls `calendar:now_to_datetime/1` for these timestamps.

Opened a PR [here](https://github.com/talentdeficit/jsx/pull/161) as well but it seems like this project is not alive any more.

The reason:
```
The call jsx:encode(Timestamp::{_,_,_}) will never return since the success typing is
(atom() | binary() | [any()] | number() | {{non_neg_integer(),1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12,1..255},{byte(),byte(),byte()}} | map()) -> binary()
and the contract is (Source::json_term()) -> json_text()
```